### PR TITLE
catch 'vulnerable-dependency-found' event from scanner to return a proper grunt error

### DIFF
--- a/tasks/retire.js
+++ b/tasks/retire.js
@@ -38,6 +38,11 @@ module.exports = function (grunt) {
       scanner.registerWarnLogger(grunt.log.error);
       scanner.registerInfoLogger(grunt.log.writeln);
 
+      // required to throw proper grunt error
+      scanner.on('vulnerable-dependency-found', function(e) {
+          vulnsFound = true;
+      });
+
       grunt.event.once('retire-js-repo', function() {
          filesSrc.forEach(function(filepath) {
             if(grunt.file.exists(filepath) && filepath.match(/\.js$/) && grunt.file.isFile(filepath)) {


### PR DESCRIPTION
The current version does not return a grunt error is a vulnerable was found. This hotfix fixes the behavior.
