### PR TITLE
Add options to the scanner.scanDependencies call

### DIFF
--- a/tasks/retire.js
+++ b/tasks/retire.js
@@ -74,7 +74,7 @@ module.exports = function (grunt) {
                grunt.log.writeln('Checking:', filepath);
             }              
             resolve.getNodeDependencies(filepath).on('done', function(dependencies) {
-               scanner.scanDependencies(dependencies, nodeRepo);
+               scanner.scanDependencies(dependencies, nodeRepo, options);
                grunt.event.emit('retire-node-scan', filesSrc.slice(1));        
            });
          } else {


### PR DESCRIPTION
Because the options parameter was not sent to scanner.scanDependencies, it failed when it tried to print a vulnerability using `log(options).warn(result.component + ' ' + result.version + ' has known vulnerabilities: ' + result.vulnerabilities.join(' '));`. Sending the options parameter fixes this issue.
