### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,19 +21,19 @@
   "scripts": {
     "test": "grunt test"
   },
-  "dependencies" : {
-    "retire"  : "~1.1.x",
-    "async"   : "~1.5.x",
-    "request" : "~2.67.x"
+  "dependencies": {
+    "retire": "~1.1.x",
+    "async": "~1.5.x",
+    "request": "~2.67.x"
   },
-  "devDependencies" : {
-    "grunt"   : "~0.4.x",
-    "grunt-contrib-jshint"   : "~0.11.x",
-    "grunt-contrib-clean"    : "~0.7.x",
-    "grunt-contrib-nodeunit" : "0.4.x"
+  "devDependencies": {
+    "grunt": "~0.4.x",
+    "grunt-contrib-jshint": "~0.11.x",
+    "grunt-contrib-clean": "~0.7.x",
+    "grunt-contrib-nodeunit": "0.4.x"
   },
   "peerDependencies": {
-    "grunt": "~0.4.x"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",
@@ -43,11 +43,11 @@
   "contributors": [
     {
       "name": "Alexander Vassbotn Røyne-Helgesen",
-      "email" : "alexander@phun-ky.net"
+      "email": "alexander@phun-ky.net"
     },
     {
       "name": "Erlend Oftedal",
-      "email" : "erlend@oftedal.no"
+      "email": "erlend@oftedal.no"
     }
   ]
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
