### PR TITLE
Improve vulnerability ignoring (https://github.com/RetireJS/retire.js/issues/67).

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Example configuration below shows default option values and the correct syntax t
          nodeRepository: 'https://raw.github.com/RetireJS/retire.js/master/repository/npmrepository.json',
          outputFile: './retire-output.json',
          ignore: 'documents,java',
-         ignorefile: '.retireignore' /** list of files to ignore **/
+         /** list of files to ignore **/
+         ignorefile: '.retireignore' //or '.retireignore.json'
       }
     }
 ```
@@ -106,7 +107,7 @@ Node repository loaded from: https://raw.github.com/RetireJS/retire.js/master/re
 
 
 
-## Example output when no vulnerabilities is found
+## Example output when no vulnerabilities are found
 ```
 ➜  grunt-retire git:(master) ✗ grunt retire
 Running "retire:jsPath" (retire) task

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
   },
   "dependencies": {
-    "retire": "~1.1.x",
+    "retire": "~1.2.x",
     "async": "~1.5.x",
     "request": "~2.67.x"
   },
@@ -47,6 +47,10 @@
     {
       "name": "Erlend Oftedal",
       "email": "erlend@oftedal.no"
+    },
+    {
+      "name": "Sergey Zarouski",
+      "email": "sergey@webuniverse.io"
     }
   ]
 }

--- a/tasks/retire.js
+++ b/tasks/retire.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
       var vulnsFound = false;
       var filesSrc = this.filesSrc;
       var request = req;
-      var defaultIgnoreFile = '.retireignore';
+      var defaultIgnoreFiles = ['.retireignore', '.retireignore.json'];
       var output = {};
       var scanedFile;
 
@@ -45,7 +45,7 @@ module.exports = function (grunt) {
       // Merge task-specific and/or target-specific options with these defaults.
       var options = this.options({
          verbose: true,
-         packageOnly: false, 
+         packageOnly: false,
          jsRepository: 'https://raw.github.com/RetireJS/retire.js/master/repository/jsrepository.json',
          nodeRepository: 'https://raw.github.com/RetireJS/retire.js/master/repository/npmrepository.json',
          logger: grunt.log.writeln,
@@ -58,8 +58,12 @@ module.exports = function (grunt) {
          options.cachedir = path.resolve(os.tmpdir(), '.retire-cache/');
       }
       var ignores = options.ignore ? options.ignore.split(',') : [];
-      options.ignore = [];
-      if (!options.ignorefile && grunt.file.exists(defaultIgnoreFile)) {
+      options.ignore = { paths : [], descriptors: [] };
+      var defaultIgnoreFile = defaultIgnoreFiles.find(function (x) {
+         return fs.existsSync(x);
+      });
+
+      if (!options.ignorefile && defaultIgnoreFile) {
         options.ignorefile = defaultIgnoreFile;
       }
 
@@ -68,12 +72,24 @@ module.exports = function (grunt) {
           grunt.log.error('Error: Could not read ignore file: ' + options.ignorefile);
           process.exit(1);
         }
-        var lines = fs.readFileSync(options.ignorefile).toString().split(/\r\n|\n/g).filter(function(e) { return e !== ''; });
-        var ignored = lines.map(function(e) { return e[0] === '@' ? e.slice(1) : path.resolve(e); });
-        options.ignore = options.ignore.concat(ignored);
+        var ignored;
+        if (options.ignorefile.substr(-5) === ".json") {
+           ignored = JSON.parse(fs.readFileSync(options.ignorefile).toString());
+           options.ignore.descriptors = ignored;
+           var ignoredPaths = ignored.map(function (x) {
+              return x.path;
+           }).filter(function (x) {
+              return x;
+           });
+           options.ignore.paths = options.ignore.paths.concat(ignoredPaths);
+        } else {
+           var lines = fs.readFileSync(options.ignorefile).toString().split(/\r\n|\n/g).filter(function(e) { return e !== ''; });
+           ignored = lines.map(function(e) { return e[0] === '@' ? e.slice(1) : path.resolve(e); });
+           options.ignore.paths = options.ignore.paths.concat(ignored);
+        }
       }
 
-      ignores.forEach(function(e) { options.ignore.push(e); });
+      ignores.forEach(function(e) { options.ignore.paths.push(e); });
       logger.verbose("Ignoring " + JSON.stringify(options.ignore));
 
       // log (verbose) options before hooking in the reporter


### PR DESCRIPTION
This change updates retirejs to 1.2.x which now supports vulnerability ignoring based on library version or even issue number. Note that retirejs only implements those features for .retireignore.json, so if you want extra ignoring, you'll need to update your .retireignore to use following format: https://github.com/RetireJS/retire.js/blob/master/example.retireignore.json.
