### PR TITLE
Added support for severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Example configuration below shows default option values and the correct syntax t
       js: ['app/src/*.js'], /** Which js-files to scan. **/
       node: ['node'], /** Which node directories to scan (containing package.json). **/
       options: {
+         severity: 'all',            //accepted values are all, none, low, medium, high, critical
          proxy: 'http://something.something:8080',
          verbose: true,
          packageOnly: true, 


### PR DESCRIPTION
Usage:

On Gruntfile add severity in retire configuration to indicate the minimum severity that will cause grunt task to fail. Note that all vulnerabilities are still displayed for reference. 

Not passing the severity value will trigger default of 'all' which keeps the task behaving as it is now; i.e., any vulnerability found will cause grunt to fail regardless of the severity.

On the other hand, severity of 'none' will cause grunt task to always pass.